### PR TITLE
Add search variants and feedback targets to the detection benchmark

### DIFF
--- a/examples/detection_benchmark/main.rs
+++ b/examples/detection_benchmark/main.rs
@@ -62,7 +62,7 @@ fn run_cmd(args: &mut noargs::RawArgs) -> Result<bool, Error> {
         .then(|o| o.value().parse())?;
     let variant_name: String = opt("variant")
         .ty("NAME")
-        .doc("Generator variant: uniform | biased (or base for the ground-truth SUT)")
+        .doc("Search variant: uniform | biased | targeted | semantic-only | semantic-with-priority (or base for the ground-truth SUT)")
         .example("uniform")
         .take(args)
         .then(|o| o.value().parse())?;
@@ -105,7 +105,10 @@ fn run_cmd(args: &mut noargs::RawArgs) -> Result<bool, Error> {
     let variant = variants::Variant::from_str(&variant_name).ok_or_else(|| {
         Error::other(
             args,
-            format!("unknown variant {variant_name:?}; available: base, uniform, biased"),
+            format!(
+                "unknown variant {variant_name:?}; available: base, uniform, biased, \
+                 targeted, semantic-only, semantic-with-priority"
+            ),
         )
     })?;
 
@@ -223,17 +226,38 @@ fn print_summary(summaries: &summary::Summaries) {
             .map(|(q25, q75)| format!("{q25}-{q75}"))
             .unwrap_or_else(|| "-".to_string());
         let buckets: Vec<String> = s.detection_buckets.iter().map(|v| v.to_string()).collect();
+        let candidate_median = s
+            .median_candidates()
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let candidate_quartiles = s
+            .candidate_quartiles()
+            .map(|(q25, q75)| format!("{q25}-{q75}"))
+            .unwrap_or_else(|| "-".to_string());
+        let candidate_buckets: Vec<String> =
+            s.candidate_buckets.iter().map(|v| v.to_string()).collect();
+        let discovered = s
+            .median_discovered_features()
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let corpus = s
+            .median_max_corpus_size()
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
         println!(
             "variant={variant} workload={workload} mutant={mutant} \
              trials={} found={} not_found={} gave_up={} aborted={} \
              detection_rate={detection_rate:.3} median={median} quartiles={quartiles} \
-             buckets=[{}]",
+             buckets=[{}] candidate_median={candidate_median} \
+             candidate_quartiles={candidate_quartiles} candidate_buckets=[{}] \
+             discovered_features_median={discovered} max_corpus_size_median={corpus}",
             s.trials,
             s.found,
             s.not_found,
             s.gave_up,
             s.aborted,
-            buckets.join(",")
+            buckets.join(","),
+            candidate_buckets.join(",")
         );
     }
 }

--- a/examples/detection_benchmark/raw.rs
+++ b/examples/detection_benchmark/raw.rs
@@ -4,7 +4,7 @@ use nojson::DisplayJson;
 
 /// Version of the raw-result format. Bump when the meaning of any field
 /// changes so old artifacts are not silently reinterpreted.
-pub(crate) const FORMAT_VERSION: u32 = 1;
+pub(crate) const FORMAT_VERSION: u32 = 2;
 
 /// Terminal state of one task trial.
 #[derive(Debug, Clone, Copy)]
@@ -52,6 +52,12 @@ pub(crate) struct RawResult {
     pub accepted_iterations: usize,
     pub rejected_iterations: usize,
     pub total_samples: usize,
+    /// Distinct semantic features registered in the global observation
+    /// set (corpus-guided variants only; 0 otherwise).
+    pub discovered_features: usize,
+    /// Combined accepted + rejected corpus size at the end of the run
+    /// (corpus-guided variants only; 0 otherwise).
+    pub max_corpus_size: usize,
     /// Workload-specific observations gathered during the run
     /// (e.g. the dependent workload's semantic-bucket reach counts).
     pub observations: Vec<(&'static str, u64)>,
@@ -72,6 +78,8 @@ impl DisplayJson for RawResult {
             f.member("accepted_iterations", self.accepted_iterations)?;
             f.member("rejected_iterations", self.rejected_iterations)?;
             f.member("total_samples", self.total_samples)?;
+            f.member("discovered_features", self.discovered_features)?;
+            f.member("max_corpus_size", self.max_corpus_size)?;
             f.member(
                 "observations",
                 nojson::array(|f| {

--- a/examples/detection_benchmark/summary.rs
+++ b/examples/detection_benchmark/summary.rs
@@ -18,6 +18,28 @@ fn bucket_of(detected_at: usize) -> usize {
         .unwrap_or(DETECTION_BUCKETS.len())
 }
 
+/// Nearest-rank median of `values` (upper median, i.e. index `n / 2`).
+fn median_of(values: &[usize]) -> Option<usize> {
+    let n = values.len();
+    if n == 0 {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    Some(sorted[n / 2])
+}
+
+/// Nearest-rank quartiles of `values` (indices `n / 4` and `3n / 4`).
+fn quartiles_of(values: &[usize]) -> Option<(usize, usize)> {
+    let n = values.len();
+    if n == 0 {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    Some((sorted[n / 4], sorted[3 * n / 4]))
+}
+
 /// Per-task summary across seeds.
 #[derive(Debug, Default)]
 pub(crate) struct TaskSummary {
@@ -31,6 +53,18 @@ pub(crate) struct TaskSummary {
     pub detection_times: Vec<usize>,
     /// Detection-time bucket counts (index = `bucket_of`).
     pub detection_buckets: [usize; 4],
+    /// Candidate executions-to-detection across `found` trials
+    /// (accepted + rejected + the failing case). One-based; excludes
+    /// the search warm-up cost from the iterations metric by counting
+    /// every candidate.
+    pub candidate_times: Vec<usize>,
+    /// Candidate-count bucket counts (index = `bucket_of`).
+    pub candidate_buckets: [usize; 4],
+    /// Distinct observed features per trial (corpus-guided variants
+    /// only; uniform / biased report 0).
+    pub discovered_features: Vec<usize>,
+    /// Combined corpus size per trial (corpus-guided variants only).
+    pub max_corpus_sizes: Vec<usize>,
 }
 
 impl TaskSummary {
@@ -43,25 +77,29 @@ impl TaskSummary {
     }
 
     pub fn median_detection(&self) -> Option<usize> {
-        let n = self.detection_times.len();
-        if n == 0 {
-            return None;
-        }
-        let mut times = self.detection_times.clone();
-        times.sort_unstable();
-        Some(times[n / 2])
+        median_of(&self.detection_times)
     }
 
     /// 25th / 75th percentiles of iterations-to-detection (nearest-rank
     /// with the upper median, i.e. index `p * n` of the sorted values).
     pub fn quartiles(&self) -> Option<(usize, usize)> {
-        let n = self.detection_times.len();
-        if n == 0 {
-            return None;
-        }
-        let mut times = self.detection_times.clone();
-        times.sort_unstable();
-        Some((times[n / 4], times[3 * n / 4]))
+        quartiles_of(&self.detection_times)
+    }
+
+    pub fn median_candidates(&self) -> Option<usize> {
+        median_of(&self.candidate_times)
+    }
+
+    pub fn candidate_quartiles(&self) -> Option<(usize, usize)> {
+        quartiles_of(&self.candidate_times)
+    }
+
+    pub fn median_discovered_features(&self) -> Option<usize> {
+        median_of(&self.discovered_features)
+    }
+
+    pub fn median_max_corpus_size(&self) -> Option<usize> {
+        median_of(&self.max_corpus_sizes)
     }
 }
 
@@ -78,6 +116,8 @@ pub(crate) fn accumulate(summaries: &mut Summaries, raw: &ParsedRaw) {
         ))
         .or_default();
     entry.trials += 1;
+    entry.discovered_features.push(raw.discovered_features);
+    entry.max_corpus_sizes.push(raw.max_corpus_size);
     match raw.status {
         Status::Found => {
             entry.found += 1;
@@ -87,6 +127,14 @@ pub(crate) fn accumulate(summaries: &mut Summaries, raw: &ParsedRaw) {
                 .expect("found status always carries a numeric detected_at");
             entry.detection_times.push(detected_at);
             entry.detection_buckets[bucket_of(detected_at)] += 1;
+            // Candidate executions-to-detection: the accepted cases,
+            // the rejected cases, and the failing case itself (which
+            // is neither accepted nor rejected). The run stops at the
+            // failure, so the run-end stats equal the detection-point
+            // stats.
+            let candidates = raw.accepted_iterations + raw.rejected_iterations + 1;
+            entry.candidate_times.push(candidates);
+            entry.candidate_buckets[bucket_of(candidates)] += 1;
         }
         Status::NotFound => entry.not_found += 1,
         Status::GaveUp => entry.gave_up += 1,
@@ -104,6 +152,10 @@ pub(crate) struct ParsedRaw {
     pub mutant: String,
     pub status: Status,
     pub detected_at: Option<usize>,
+    pub accepted_iterations: usize,
+    pub rejected_iterations: usize,
+    pub discovered_features: usize,
+    pub max_corpus_size: usize,
 }
 
 /// Parse one raw-result JSON line. Returns `None` for blank lines;
@@ -183,6 +235,10 @@ pub(crate) fn parse_line(line: &str) -> Result<Option<ParsedRaw>, String> {
         mutant: get_str("mutant")?,
         status,
         detected_at,
+        accepted_iterations: get_u64("accepted_iterations")? as usize,
+        rejected_iterations: get_u64("rejected_iterations")? as usize,
+        discovered_features: get_u64("discovered_features")? as usize,
+        max_corpus_size: get_u64("max_corpus_size")? as usize,
     }))
 }
 /// Read raw results from a reader (one JSON line per task) and return
@@ -219,7 +275,7 @@ mod tests {
     /// Minimal raw-result line for `parse_line` unit tests.
     fn line(status: &str, detected_at: &str) -> String {
         format!(
-            r#"{{"format_version":1,"workload":"w","mutant":"m","variant":"v","status":"{status}","detected_at":{detected_at}}}"#
+            r#"{{"format_version":2,"workload":"w","mutant":"m","variant":"v","status":"{status}","detected_at":{detected_at},"accepted_iterations":3,"rejected_iterations":2,"discovered_features":1,"max_corpus_size":1}}"#
         )
     }
 
@@ -230,6 +286,10 @@ mod tests {
             .expect("non-blank");
         assert!(matches!(raw.status, Status::Found));
         assert_eq!(raw.detected_at, Some(7));
+        assert_eq!(raw.accepted_iterations, 3);
+        assert_eq!(raw.rejected_iterations, 2);
+        assert_eq!(raw.discovered_features, 1);
+        assert_eq!(raw.max_corpus_size, 1);
     }
 
     #[test]
@@ -243,7 +303,7 @@ mod tests {
 
     #[test]
     fn parse_line_rejects_wrong_format_version() {
-        let line = line("found", "7").replace("\"format_version\":1", "\"format_version\":99");
+        let line = line("found", "7").replace("\"format_version\":2", "\"format_version\":99");
         let err = parse_line(&line).expect_err("wrong format version must be rejected");
         assert!(err.contains("unsupported format_version 99"), "{err}");
     }
@@ -263,7 +323,7 @@ mod tests {
     #[test]
     fn parse_line_rejects_missing_required_fields() {
         let input =
-            r#"{"format_version":1,"workload":"w","mutant":"m","status":"found","detected_at":1}"#;
+            r#"{"format_version":2,"workload":"w","mutant":"m","status":"found","detected_at":1}"#;
         let err = parse_line(input).expect_err("missing variant must be rejected");
         assert!(err.contains("variant"), "{err}");
     }
@@ -304,6 +364,10 @@ mod tests {
             mutant: "fails_on_zero".to_string(),
             status: Status::NotFound,
             detected_at: None,
+            accepted_iterations: 100,
+            rejected_iterations: 0,
+            discovered_features: 0,
+            max_corpus_size: 0,
         };
         accumulate(&mut summaries, &raw);
         let entry = summaries
@@ -316,5 +380,31 @@ mod tests {
         assert_eq!(entry.trials, 1);
         assert_eq!(entry.not_found, 1);
         assert_eq!(entry.detection_times.len(), 0);
+        assert_eq!(entry.candidate_times.len(), 0);
+    }
+
+    #[test]
+    fn accumulate_counts_candidate_executions_on_found() {
+        let mut summaries = Summaries::new();
+        let raw = ParsedRaw {
+            variant: "targeted".to_string(),
+            workload: "w".to_string(),
+            mutant: "m".to_string(),
+            status: Status::Found,
+            detected_at: Some(4),
+            accepted_iterations: 4,
+            rejected_iterations: 7,
+            discovered_features: 0,
+            max_corpus_size: 0,
+        };
+        accumulate(&mut summaries, &raw);
+        let entry = summaries
+            .get(&("targeted".to_string(), "w".to_string(), "m".to_string()))
+            .expect("group must exist");
+        assert_eq!(entry.found, 1);
+        // accepted + rejected + the failing case itself.
+        assert_eq!(entry.candidate_times, vec![12]);
+        assert_eq!(entry.candidate_buckets[bucket_of(12)], 1);
+        assert_eq!(entry.discovered_features, vec![0]);
     }
 }

--- a/examples/detection_benchmark/targets/boundary.rs
+++ b/examples/detection_benchmark/targets/boundary.rs
@@ -29,6 +29,13 @@ fn run(
     } else {
         noprop::sample_u32(ctx)
     };
+    // Feedback: the mutant fails for x == 0, so the priority rewards
+    // values close to zero (measured by leading zeros, 0..=32) and the
+    // bucket observes that distance in finite steps. These calls draw
+    // no random bytes, so the generator stream is unchanged.
+    let zeros = x.leading_zeros();
+    ctx.bucket("leading_zeros", zeros as u64);
+    ctx.maximize(zeros as f64 / 32.0);
     process(x, sut_mutant).map_err(|_| format!("process failed for x={x}"))
 }
 

--- a/examples/detection_benchmark/targets/bst.rs
+++ b/examples/detection_benchmark/targets/bst.rs
@@ -144,6 +144,12 @@ fn run(
         } else {
             noprop::sample_usize_in(ctx, 0..1024) as u32
         };
+        // Feedback: the mutant fails when a key is inserted twice,
+        // which a small key range makes likely; the priority rewards
+        // small keys and the event observes duplicate insertion
+        // attempts. These calls draw no random bytes, so the generator
+        // stream is unchanged.
+        ctx.maximize(if key < 8 { 1.0 } else { 0.0 });
         // 80% insert under the biased variant, 50% otherwise.
         let insert = if biased {
             noprop::sample_usize_in(ctx, 0..10) < 8
@@ -151,6 +157,9 @@ fn run(
             noprop::sample_bool(ctx)
         };
         if insert {
+            if bst.contains(key) {
+                ctx.event("duplicate_key");
+            }
             bst.insert(key, sut_mutant);
             model.insert(key, ());
         } else {
@@ -158,6 +167,10 @@ fn run(
             model.remove(&key);
         }
     }
+    // `maximize` is mandatory in targeted mode: report a score even
+    // when no operation was generated. The case-local maximum keeps
+    // any in-loop score.
+    ctx.maximize(0.0);
 
     // Property: the BST's in-order keys must match the model exactly.
     let actual = bst.keys();

--- a/examples/detection_benchmark/targets/combination.rs
+++ b/examples/detection_benchmark/targets/combination.rs
@@ -31,6 +31,13 @@ fn run(
 ) -> Result<(), String> {
     let x = draw(if biased { Some(1) } else { None }, ctx);
     let y = draw(if biased { Some(2) } else { None }, ctx);
+    // Feedback: the mutant fails for the exact pair (1, 2), so the
+    // priority rewards each draw landing on its witness value and the
+    // events observe the two conditions separately. These calls draw
+    // no random bytes, so the generator stream is unchanged.
+    ctx.event(if x == 1 { "x_witness" } else { "x_other" });
+    ctx.event(if y == 2 { "y_witness" } else { "y_other" });
+    ctx.maximize((if x == 1 { 0.5 } else { 0.0 }) + (if y == 2 { 0.5 } else { 0.0 }));
     process(x, y, sut_mutant).map_err(|_| format!("process failed for ({x}, {y})"))
 }
 

--- a/examples/detection_benchmark/targets/dependent.rs
+++ b/examples/detection_benchmark/targets/dependent.rs
@@ -58,6 +58,17 @@ fn run(
         1,
     );
 
+    // Feedback: the mutant misreads the duration when both bits are
+    // set, so the priority rewards flags close to 0b11 and the bucket
+    // observes the flag distribution. These calls draw no random
+    // bytes, so the generator stream is unchanged.
+    ctx.bucket("flags", flags as u64);
+    ctx.maximize(match flags {
+        0b11 => 1.0,
+        0b10 | 0b01 => 0.5,
+        _ => 0.0,
+    });
+
     let duration = noprop::sample_u32(ctx);
     let size = noprop::sample_u32(ctx);
     let parsed_duration = parse_trun(flags, duration, size, sut_mutant).0;

--- a/examples/detection_benchmark/targets/guard.rs
+++ b/examples/detection_benchmark/targets/guard.rs
@@ -1,0 +1,47 @@
+//! Guard target: reports effectively unbounded bucket values on every
+//! case to verify that the corpus-guided machinery stays bounded (the
+//! global feature registry saturates at 1024 and the corpus at 64)
+//! and deterministic across all variants. No mutant: detection is
+//! never expected, and every variant must complete the run.
+
+use super::{Observe, Task, Workload};
+use noprop::TestCaseContext;
+
+fn run_case(
+    _sut_mutant: bool,
+    _biased: bool,
+    ctx: &mut TestCaseContext,
+    _obs: &Observe,
+) -> Result<(), String> {
+    // Report fresh near-uniform values on every case: a property that
+    // misuses `bucket` with an unbounded value must not grow memory
+    // without bound or abort the run. The per-case cap truncates the
+    // reports and the global registry saturates.
+    for _ in 0..64 {
+        let v = noprop::sample_u64(ctx);
+        ctx.bucket("noise", v);
+    }
+    ctx.maximize(0.5);
+    Ok(())
+}
+
+pub(crate) const WORKLOAD: Workload = Workload {
+    name: "guard",
+    description: "reports unbounded bucket values; checks corpus bounds and determinism",
+    tasks: &[Task {
+        mutant: "reports_unbounded_buckets",
+        base: run_case_base,
+        uniform: run_case_uniform,
+        biased: run_case_biased,
+    }],
+};
+
+fn run_case_base(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run_case(false, false, ctx, obs)
+}
+fn run_case_uniform(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run_case(true, false, ctx, obs)
+}
+fn run_case_biased(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run_case(true, true, ctx, obs)
+}

--- a/examples/detection_benchmark/targets/high_frequency.rs
+++ b/examples/detection_benchmark/targets/high_frequency.rs
@@ -32,6 +32,11 @@ fn run(
     } else {
         noprop::sample_u32(ctx)
     };
+    // Feedback: the mutant fails for odd x, so the priority rewards
+    // odd draws and the event observes which parity was reached. These
+    // calls draw no random bytes, so the generator stream is unchanged.
+    ctx.event(if x.is_multiple_of(2) { "even" } else { "odd" });
+    ctx.maximize(if x.is_multiple_of(2) { 0.0 } else { 1.0 });
     process(x, sut_mutant).map_err(|_| format!("process failed for x={x}"))
 }
 

--- a/examples/detection_benchmark/targets/mod.rs
+++ b/examples/detection_benchmark/targets/mod.rs
@@ -6,13 +6,19 @@ mod boundary;
 mod bst;
 mod combination;
 mod dependent;
+mod guard;
 mod high_frequency;
+mod stateful;
+mod stepping;
 
 pub(crate) use self::boundary::WORKLOAD as BOUNDARY;
 pub(crate) use self::bst::WORKLOAD as BST;
 pub(crate) use self::combination::WORKLOAD as COMBINATION;
 pub(crate) use self::dependent::WORKLOAD as DEPENDENT;
+pub(crate) use self::guard::WORKLOAD as GUARD;
 pub(crate) use self::high_frequency::WORKLOAD as HIGH_FREQUENCY;
+pub(crate) use self::stateful::WORKLOAD as STATEFUL;
+pub(crate) use self::stepping::WORKLOAD as STEPPING;
 
 /// A property run: generate an input from `ctx`, exercise the SUT, and
 /// return `Err` when the property fails.
@@ -44,7 +50,16 @@ pub(crate) struct Workload {
 }
 
 /// All registered workloads, keyed by `Workload::name`.
-pub(crate) const WORKLOADS: &[Workload] = &[HIGH_FREQUENCY, BOUNDARY, COMBINATION, DEPENDENT, BST];
+pub(crate) const WORKLOADS: &[Workload] = &[
+    HIGH_FREQUENCY,
+    BOUNDARY,
+    COMBINATION,
+    DEPENDENT,
+    BST,
+    STEPPING,
+    STATEFUL,
+    GUARD,
+];
 
 /// Observation sink for workload-specific measurements.
 ///

--- a/examples/detection_benchmark/targets/stateful.rs
+++ b/examples/detection_benchmark/targets/stateful.rs
@@ -1,0 +1,60 @@
+//! Stateful transition target: a synthetic command-sequence workload.
+//! Each case applies `advance` / `reset` commands to an abstract
+//! state; the mutant fails once the state reaches 7. Every case runs
+//! the same code path — only the transition combination differs, which
+//! is exactly what the corpus-guided search observes.
+
+use super::{Observe, Task, Workload};
+use noprop::TestCaseContext;
+
+fn run(
+    sut_mutant: bool,
+    biased: bool,
+    ctx: &mut TestCaseContext,
+    _obs: &Observe,
+) -> Result<(), String> {
+    let mut state = 0u64;
+    let steps = noprop::sample_usize_in(ctx, 0..32);
+    for _ in 0..steps {
+        let advance = if biased {
+            // 95% advance, so seven consecutive advances are common.
+            noprop::sample_usize_in(ctx, 0..20) < 19
+        } else {
+            noprop::sample_bool(ctx)
+        };
+        let next = if advance { state + 1 } else { 0 };
+        // Feedback: the transitions observe the path taken (the same
+        // code path for every case); this call draws no random bytes,
+        // so the generator stream is unchanged.
+        ctx.transition("state", state, next);
+        state = next;
+        if sut_mutant && state >= 7 {
+            return Err(format!("state reached {state}"));
+        }
+    }
+    // Feedback: the mutant fails at state 7, so the priority rewards
+    // the current state. This call draws no random bytes.
+    ctx.maximize(state as f64 / 7.0);
+    Ok(())
+}
+
+pub(crate) const WORKLOAD: Workload = Workload {
+    name: "stateful",
+    description: "mutant fails when the abstract state reaches 7; transitions are observable",
+    tasks: &[Task {
+        mutant: "fails_on_state_seven",
+        base: run_base,
+        uniform: run_uniform,
+        biased: run_biased,
+    }],
+};
+
+fn run_base(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run(false, false, ctx, obs)
+}
+fn run_uniform(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run(true, false, ctx, obs)
+}
+fn run_biased(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run(true, true, ctx, obs)
+}

--- a/examples/detection_benchmark/targets/stepping.rs
+++ b/examples/detection_benchmark/targets/stepping.rs
@@ -1,0 +1,65 @@
+//! Sparse-precondition target: the mutant fails only when five
+//! consecutive draws are all zero. Uniform sampling reaches the
+//! witness with probability 1e-5 per case; the biased variant draws
+//! zero with probability 0.7. The progress toward the precondition
+//! (the number of leading zero draws) is observable as a bucket, so
+//! the search policies can be seen steering along the progress axis.
+
+use super::{Observe, Task, Workload};
+use noprop::TestCaseContext;
+
+fn run(
+    sut_mutant: bool,
+    biased: bool,
+    ctx: &mut TestCaseContext,
+    _obs: &Observe,
+) -> Result<(), String> {
+    let mut progress = 0u64;
+    for _ in 0..5 {
+        let x = if biased {
+            // 70% exactly zero, otherwise 1..10 (never zero).
+            if noprop::sample_usize_in(ctx, 0..10) < 7 {
+                0
+            } else {
+                noprop::sample_usize_in(ctx, 1..10)
+            }
+        } else {
+            noprop::sample_usize_in(ctx, 0..10)
+        };
+        if x != 0 {
+            break;
+        }
+        progress += 1;
+    }
+    // Feedback: the mutant fails at full progress, so the priority
+    // rewards the progress and the bucket observes it in finite steps.
+    // These calls draw no random bytes, so the generator stream is
+    // unchanged.
+    ctx.bucket("progress", progress);
+    ctx.maximize(progress as f64 / 5.0);
+    if sut_mutant && progress == 5 {
+        return Err("all five consecutive draws were zero".to_string());
+    }
+    Ok(())
+}
+
+pub(crate) const WORKLOAD: Workload = Workload {
+    name: "stepping",
+    description: "mutant fails only after five consecutive zero draws; progress is observable",
+    tasks: &[Task {
+        mutant: "fails_on_five_zeros",
+        base: run_base,
+        uniform: run_uniform,
+        biased: run_biased,
+    }],
+};
+
+fn run_base(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run(false, false, ctx, obs)
+}
+fn run_uniform(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run(true, false, ctx, obs)
+}
+fn run_biased(ctx: &mut TestCaseContext, obs: &Observe) -> Result<(), String> {
+    run(true, true, ctx, obs)
+}

--- a/examples/detection_benchmark/variants.rs
+++ b/examples/detection_benchmark/variants.rs
@@ -1,26 +1,44 @@
-//! Generator variants: how the input space is sampled. The property
-//! and SUT are identical across variants; only the generator differs.
+//! Generator variants: how the input space is sampled and which runner
+//! entry point drives the property. The SUT is identical across
+//! variants; only the generator and the search policy differ.
 //! (`Variant::Base` is the exception: it runs the base SUT as a
 //! ground-truth check, not a comparison variant.)
+//!
+//! The uniform / biased properties report semantic feedback (`event` /
+//! `bucket` / `transition`) and a scalar priority (`maximize`) so the
+//! same property runs under every search policy; in uniform mode the
+//! feedback methods are allocation-free no-ops, so the uniform /
+//! biased results match the recorded baseline (the feedback calls draw
+//! no random bytes).
 
 use std::time::Instant;
 
-use noprop::{Error, Runner, Stats};
+use noprop::{CorpusPolicy, Error, Runner, Stats, TestCaseContext};
 
 use crate::raw::{RawResult, Status};
-use crate::targets::{Observe, Task};
+use crate::targets::{Observe, Property, Task};
 
-/// Generator variant for a task.
+/// Generator / search variant for a task.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Variant {
     /// Base SUT under uniform generation. Ground-truth check: must
     /// complete the property for any input. Not part of the
     /// comparison; use via the `run` subcommand.
     Base,
-    /// Uniform generation.
+    /// Uniform generation under `Runner::run`.
     Uniform,
-    /// Explicitly biased generation (`match` + weighted choice).
+    /// Explicitly biased generation (`match` + weighted choice) under
+    /// `Runner::run`.
     Biased,
+    /// Targeted search (`Runner::run_targeted`) over the scalar
+    /// priority reported by the property.
+    Targeted,
+    /// Corpus-guided search admitting purely on feature novelty
+    /// (`run_corpus_guided_with_policy(SemanticOnly)`).
+    SemanticOnly,
+    /// Integrated search: semantic corpus plus scalar priority
+    /// (`Runner::run_corpus_guided`, i.e. `SemanticWithPriority`).
+    SemanticWithPriority,
 }
 
 impl Variant {
@@ -29,6 +47,9 @@ impl Variant {
             "base" => Some(Variant::Base),
             "uniform" => Some(Variant::Uniform),
             "biased" => Some(Variant::Biased),
+            "targeted" => Some(Variant::Targeted),
+            "semantic-only" => Some(Variant::SemanticOnly),
+            "semantic-with-priority" => Some(Variant::SemanticWithPriority),
             _ => None,
         }
     }
@@ -38,12 +59,21 @@ impl Variant {
             Variant::Base => "base",
             Variant::Uniform => "uniform",
             Variant::Biased => "biased",
+            Variant::Targeted => "targeted",
+            Variant::SemanticOnly => "semantic-only",
+            Variant::SemanticWithPriority => "semantic-with-priority",
         }
     }
 }
 
 /// Comparison variants used by `run-all`.
-pub(crate) const VARIANTS: &[Variant] = &[Variant::Uniform, Variant::Biased];
+pub(crate) const VARIANTS: &[Variant] = &[
+    Variant::Uniform,
+    Variant::Biased,
+    Variant::Targeted,
+    Variant::SemanticOnly,
+    Variant::SemanticWithPriority,
+];
 
 /// Run one task (workload x mutant x variant) for a fixed seed and
 /// iteration budget, returning the raw result.
@@ -55,15 +85,10 @@ pub(crate) fn run_task(
     iterations: usize,
 ) -> RawResult {
     let observe = Observe::default();
-    let property = match variant {
-        Variant::Base => task.base,
-        Variant::Uniform => task.uniform,
-        Variant::Biased => task.biased,
-    };
 
     let start = Instant::now();
     let mut runner = Runner::new(seed, iterations);
-    let outcome = runner.run(|ctx| property(ctx, &observe).map_err(Into::into));
+    let outcome = run_variant(&mut runner, task, variant, &observe);
     let wall_clock_ns = start.elapsed().as_nanos();
     let stats: Stats = runner.stats();
     let observations = observe.take();
@@ -82,18 +107,50 @@ pub(crate) fn run_task(
         accepted_iterations: stats.accepted_iterations,
         rejected_iterations: stats.rejected_iterations,
         total_samples: stats.total_samples,
+        discovered_features: stats.discovered_features,
+        max_corpus_size: stats.max_corpus_size,
         observations,
         wall_clock_ns,
     }
 }
 
+/// Drive the task's property under the variant's runner entry point.
+///
+/// The uniform / biased variants use the task's base / biased
+/// properties (feedback-reporting under uniform / biased generation);
+/// the search variants reuse the uniform property, whose feedback
+/// methods are no-ops under `Runner::run`.
+fn run_variant(
+    runner: &mut Runner,
+    task: &Task,
+    variant: Variant,
+    observe: &Observe,
+) -> Result<(), Error> {
+    let property: Property = match variant {
+        Variant::Base => task.base,
+        Variant::Biased => task.biased,
+        _ => task.uniform,
+    };
+    let run = |ctx: &mut TestCaseContext| property(ctx, observe).map_err(Into::into);
+    match variant {
+        Variant::Base | Variant::Uniform | Variant::Biased => runner.run(run),
+        Variant::Targeted => runner.run_targeted(run),
+        Variant::SemanticOnly => {
+            runner.run_corpus_guided_with_policy(CorpusPolicy::SemanticOnly, run)
+        }
+        Variant::SemanticWithPriority => runner.run_corpus_guided(run),
+    }
+}
+
 /// Classify the run outcome: property failure (found), rejection-cap
-/// exhaustion (gave_up), or a clean pass (not_found).
+/// exhaustion (gave_up), harness-level feedback failure (aborted), or
+/// a clean pass (not_found).
 ///
 /// `ErrorKind` is crate-private, so the classification relies on the
-/// stable `Display` wording of the too-many-rejections failure (pinned
-/// by the e2e tests). Non-rejection errors are property failures:
-/// `Runner::run` produces no other error kind today.
+/// stable `Display` wording of the failure kinds (pinned by the e2e
+/// tests). Targeted mode's missing / invalid feedback failures are
+/// harness errors of the property, not mutant detections, so they are
+/// classified as `Aborted` rather than `Found`.
 fn classify(outcome: &Result<(), Error>) -> (Status, Option<usize>) {
     match outcome {
         Ok(()) => (Status::NotFound, None),
@@ -101,6 +158,8 @@ fn classify(outcome: &Result<(), Error>) -> (Status, Option<usize>) {
             let display = format!("{err}");
             if display.contains("too many rejections") {
                 (Status::GaveUp, None)
+            } else if display.contains("missing feedback") || display.contains("invalid feedback") {
+                (Status::Aborted, None)
             } else {
                 // `case_index` is the accepted case that failed; the
                 // iterations-to-detection count includes it.

--- a/tests/detection_benchmark.rs
+++ b/tests/detection_benchmark.rs
@@ -26,13 +26,28 @@ fn ensure_built() {
     });
 }
 
-/// Workload / mutant pairs registered by the harness.
+/// Workload / mutant pairs registered by the harness, excluding the
+/// guard workload (which has no mutant and never detects).
 const TASKS: &[(&str, &str)] = &[
     ("high-frequency", "fails_on_odd"),
     ("boundary", "fails_on_zero"),
     ("combination", "fails_on_specific_pair"),
     ("dependent", "duration_field_misread"),
     ("bst", "insert_duplicate_key"),
+    ("stepping", "fails_on_five_zeros"),
+    ("stateful", "fails_on_state_seven"),
+];
+
+/// Workloads with no mutant: detection is never expected.
+const GUARD_TASKS: &[(&str, &str)] = &[("guard", "reports_unbounded_buckets")];
+
+/// Comparison variants run by `run-all`.
+const VARIANTS: &[&str] = &[
+    "uniform",
+    "biased",
+    "targeted",
+    "semantic-only",
+    "semantic-with-priority",
 ];
 
 fn run(args: &[&str]) -> String {
@@ -98,7 +113,7 @@ fn run_task(workload: &str, mutant: &str, variant: &str, seed: u64) -> String {
 /// every base run ends `not_found`.
 #[test]
 fn base_sut_completes_for_all_workloads() {
-    for (workload, mutant) in TASKS {
+    for (workload, mutant) in TASKS.iter().chain(GUARD_TASKS) {
         let line = run_task(workload, mutant, "base", 1);
         assert!(
             line.contains("\"status\":\"not_found\""),
@@ -120,16 +135,62 @@ fn mutants_are_detected_by_biased_generation() {
     }
 }
 
+/// The guard workload must never report a detection: it has no mutant.
+#[test]
+fn guard_never_detects() {
+    for (workload, mutant) in GUARD_TASKS {
+        let line = run_task(workload, mutant, "uniform", 1);
+        assert!(
+            line.contains("\"status\":\"not_found\""),
+            "guard {workload}/{mutant} must complete without detection: {line}"
+        );
+    }
+}
+
 /// Same seed and arguments must reproduce the identical raw result
-/// (the wall-clock field is timing noise and excluded).
+/// (the wall-clock field is timing noise and excluded), for every
+/// search variant.
 #[test]
 fn same_seed_is_deterministic() {
+    for (workload, mutant) in TASKS.iter().chain(GUARD_TASKS) {
+        for variant in VARIANTS {
+            let a = strip_wall_clock(&run_task(workload, mutant, variant, 42));
+            let b = strip_wall_clock(&run_task(workload, mutant, variant, 42));
+            assert_eq!(
+                a, b,
+                "{workload}/{mutant} under {variant} must be reproducible from the seed"
+            );
+        }
+    }
+}
+
+/// Every variant must complete the guard workload without aborting
+/// (the missing / invalid feedback classification is pinned here: a
+/// property failure would surface as `found`, a feedback failure as
+/// `aborted`).
+#[test]
+fn guard_completes_under_every_variant() {
+    for (workload, mutant) in GUARD_TASKS {
+        for variant in VARIANTS {
+            let line = run_task(workload, mutant, variant, 1);
+            assert!(
+                line.contains("\"status\":\"not_found\""),
+                "guard {workload}/{mutant} under {variant} must complete: {line}"
+            );
+        }
+    }
+}
+
+/// Every mutant task must report a scalar priority: targeted mode
+/// fails a case that never calls `maximize`, which the harness must
+/// classify as `aborted` rather than as a detection.
+#[test]
+fn targeted_variant_never_aborts_on_missing_feedback() {
     for (workload, mutant) in TASKS {
-        let a = strip_wall_clock(&run_task(workload, mutant, "uniform", 42));
-        let b = strip_wall_clock(&run_task(workload, mutant, "uniform", 42));
-        assert_eq!(
-            a, b,
-            "{workload}/{mutant} must be reproducible from the seed"
+        let line = run_task(workload, mutant, "targeted", 1);
+        assert!(
+            !line.contains("\"status\":\"aborted\""),
+            "{workload}/{mutant} under targeted must report a priority: {line}"
         );
     }
 }
@@ -143,13 +204,14 @@ fn summary_regenerates_from_raw_results() {
     let groups = run_with_stdin(&["summary"], Some(&raw));
     // run-all prints one JSON line per (workload, mutant, variant, seed);
     // summary prints one line per (variant, workload, mutant) group.
+    let task_count = TASKS.len() + GUARD_TASKS.len();
     let raw_lines = raw.lines().filter(|l| !l.trim().is_empty()).count();
     assert_eq!(
         raw_lines,
-        TASKS.len() * 2 * 3,
+        task_count * VARIANTS.len() * 3,
         "raw lines must match tasks x variants x seeds"
     );
-    let expected_groups = TASKS.len() * 2;
+    let expected_groups = task_count * VARIANTS.len();
     let summary_lines = groups.lines().filter(|l| l.starts_with("variant=")).count();
     assert_eq!(
         summary_lines, expected_groups,


### PR DESCRIPTION
This extends the detection benchmark to compare noprop's search policies (targeted / corpus-guided) against uniform / biased generation, and adds feedback-reporting targets.

## Changes

- `Variant` extended to 5 comparison variants: `uniform` / `biased` / `targeted` / `semantic-only` / `semantic-with-priority`, each driving a different runner entry point (`Runner::run` / `run_targeted` / `run_corpus_guided_with_policy` / `run_corpus_guided`)
- `classify` now reports targeted-mode missing / invalid feedback as `Aborted` instead of mistaking it for a detection
- The 5 existing targets report semantic feedback (`maximize` + `event` / `bucket` / `transition`); the feedback calls draw no random bytes, so uniform / biased results match the recorded baseline (verified before the campaign)
- 3 new targets:
  - `stepping`: fails after five consecutive zero draws (sparse precondition; progress observable as a bucket)
  - `stateful`: fails when the abstract state reaches 7 (command-sequence style; transitions observable)
  - `guard`: reports unbounded bucket values on every case (no mutant; checks corpus bounds and determinism)
- raw format v2: `discovered_features` / `max_corpus_size` added
- summary adds candidate executions-to-detection buckets and corpus metrics

## Campaign results (8 workloads x 64 seeds, i=1000; detection rate / median)

| workload | uniform | biased | targeted | semantic-only | integrated |
|---|---|---|---|---|---|
| high-frequency | 100% (1) | 100% (1) | 100% (2) | 100% (2) | 100% (2) |
| boundary | 0% | 100% (7) | 0% | 0% | 0% |
| combination | 0% | 100% (2) | 0% | 0% | 0% |
| dependent | 100% (3) | 100% (1) | 100% (8) | 100% (7) | 100% (7) |
| bst | 100% (75) | 100% (2) | 100% (97) | 100% (94) | 100% (94) |
| stepping | 0% | 100% (4) | 12.5% | 34.4% | 34.4% |
| stateful | 100% (15) | 100% (1) | 100% (20) | 100% (16) | 100% (23) |
| guard | 0% | 0% | 0% | 0% | 0% |

## Interpretation

- The search policies only beat uniform on a sparse precondition with observable progress (`stepping`: 0% → 34.4% under corpus-guided)
- They are ineffective on a single sparse value (boundary / combination), where generator-side bias is required
- `SemanticOnly` and `SemanticWithPriority` produced identical results on every target (the priority replacement never fired because novel features never ran out)
- The biased generator beat every search variant on every target
- Boundedness and determinism are preserved (guard: 1024 saturated features, corpus 45; no aborted runs, same-seed reproducibility)
- Search variants cost 2-7x uniform in wall-clock per case

The synthetic results show no improvement over biased generation, so real-target effectiveness determines whether the search policies ship. Both corpus policies are retained: `SemanticOnly` and `SemanticWithPriority` produced identical results on this workload set, so removing either is not justified yet.
