### PR TITLE
Fix modulo bias in printable ASCII samplers

### DIFF
--- a/docs/feedback-guided-search.md
+++ b/docs/feedback-guided-search.md
@@ -156,8 +156,8 @@ it is non-empty.
 Mutation rewrites each draw with probability 1/4 (currently). The
 rewrite depends on the draw's recorded metadata:
 
-- **Bounded / Choice** — a fresh value is drawn inside the recorded
-  domain (`sample_below` on the recorded bound / length).
+- **Bounded / Choice** — a fresh value is drawn uniformly inside the
+  recorded domain (the recorded bound, or length for Choice draws).
 - **Integer** — a fresh value of the same width is written to the
   draw (`sample_u{8,16,32,64,128}` / `sample_i*` primitives).
 - **Raw** — constraint-free draws (raw bytes, string payload, …) are

--- a/docs/generator-design.md
+++ b/docs/generator-design.md
@@ -73,11 +73,7 @@ users write their own:
   the recursive call, and return a base-case value when it hits zero.
 
 Internally, noprop's shared bounded-domain sampler — the crate-private
-core used by [`sample_usize_in`](crate::sample_usize_in),
-[`sample_ratio`](crate::sample_ratio),
-[`sample_weighted_index`](crate::sample_weighted_index),
-[`sample_choice`](crate::sample_choice), and
-[`sample_with_boundaries`](crate::sample_with_boundaries) — is bounded
+core every finite-domain selection primitive draws through — is bounded
 at 64 attempts per call. The per-attempt rejection rate is at worst ~50%
 (when the requested domain is just above a power of two), so the
 probability of exhausting all 64 attempts is `< 2⁻⁶⁴` — astronomically

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -842,12 +842,17 @@ pub fn sample_ascii_char(ctx: &mut TestCaseContext) -> char {
 
 /// Uniformly-distributed printable ASCII `char` (`0x20..=0x7E`, space
 /// through `~`, excluding control characters and DEL).
+///
+/// The 95 printable characters do not evenly divide the integer domain,
+/// so a naive `% 95` would be biased. Uses the same bounded
+/// rejection-sampling core as [`sample_usize_in`] and
+/// [`sample_choice`] to keep the distribution uniform; for this bound
+/// the per-attempt rejection rate is `< 2⁻⁶³`, so a rejection draw is
+/// effectively never taken.
 #[track_caller]
 pub fn sample_ascii_printable_char(ctx: &mut TestCaseContext) -> char {
     let loc = Location::caller();
-    // 95 characters. Use u32 for negligible modulo bias
-    // (2^32 mod 95 = 6, so bias factor is at most 1 + 1/45210182).
-    let v = (0x20 + u32::from_le_bytes(raw_bytes(ctx)) % 95) as u8 as char;
+    let v = (0x20 + sample_below(ctx, 95)) as u8 as char;
     ctx.record_generated(&v, loc);
     v
 }
@@ -942,7 +947,12 @@ pub fn sample_ascii_string(ctx: &mut TestCaseContext, len: usize) -> String {
 ///
 /// # Trace
 ///
-/// One trace entry is recorded per call; no attempt spans are opened.
+/// One trace entry is recorded per call. Each character is drawn via
+/// the same bounded rejection-sampling core as
+/// [`sample_ascii_printable_char`], so a call consumes `len × 8` RNG
+/// bytes plus a rare rejection draw (probability `< 2⁻⁶³` per
+/// character), and opens an attempt span only if a rejection occurs.
+/// Rejected draws do not appear in the value trace.
 ///
 /// # Examples
 ///
@@ -979,7 +989,7 @@ fn sample_ascii_char_raw(ctx: &mut TestCaseContext) -> char {
 }
 
 fn sample_ascii_printable_char_raw(ctx: &mut TestCaseContext) -> char {
-    (0x20 + u32::from_le_bytes(raw_bytes(ctx)) % 95) as u8 as char
+    (0x20 + sample_below(ctx, 95)) as u8 as char
 }
 
 // === Floating-point generators ===
@@ -1298,6 +1308,42 @@ mod tests {
         }
     }
 
+    #[test]
+    fn sample_ascii_printable_char_matches_unbiased_core() {
+        // 95 does not divide 2^64, so an unbiased printable draw must
+        // come from the shared rejection-sampling core. Two same-seed
+        // contexts advance in lockstep: the direct `sample_below(95)`
+        // stream must equal the char primitive's stream. A `% 95`
+        // mapping is reintroduced this fails, because it consumes a
+        // different number of RNG bytes per char and drifts off-stream.
+        let mut core = TestCaseContext::new(0x9E37_79B9_7F4A_7C15);
+        let mut sampler = TestCaseContext::new(0x9E37_79B9_7F4A_7C15);
+        for _ in 0..1024 {
+            let expected = (0x20 + sample_below(&mut core, 95)) as u8 as char;
+            assert_eq!(sample_ascii_printable_char(&mut sampler), expected);
+        }
+    }
+
+    #[test]
+    fn sample_ascii_printable_char_is_roughly_uniform() {
+        let mut ctx = TestCaseContext::new(7);
+        let mut counts = [0usize; 95];
+        let total = 190_000;
+        for _ in 0..total {
+            let idx = (sample_ascii_printable_char(&mut ctx) as u32 - 0x20) as usize;
+            counts[idx] += 1;
+        }
+        // Expected 2000 per bucket. The seed is fixed, so a generous
+        // slack of 10% makes this deterministic rather than flaky.
+        let expected = total / 95;
+        for (i, c) in counts.iter().enumerate() {
+            assert!(
+                c.abs_diff(expected) < expected / 10,
+                "bucket {i} count off: {c} vs {expected}"
+            );
+        }
+    }
+
     // === sample_string / sample_ascii_string / sample_ascii_printable_string ===
 
     #[test]
@@ -1335,6 +1381,21 @@ mod tests {
                 s.chars().all(|c| (0x20..=0x7E).contains(&(c as u32))),
                 "found non-printable in {s:?}"
             );
+        }
+    }
+
+    #[test]
+    fn sample_ascii_printable_string_matches_unbiased_core() {
+        // The string path must draw each character from the same
+        // unbiased core as the char primitive; see
+        // `sample_ascii_printable_char_matches_unbiased_core`.
+        let mut core = TestCaseContext::new(0xDEAD_BEEF_CAFE_F00D);
+        let mut sampler = TestCaseContext::new(0xDEAD_BEEF_CAFE_F00D);
+        for len in [1, 7, 32] {
+            let expected: String = (0..len)
+                .map(|_| (0x20 + sample_below(&mut core, 95)) as u8 as char)
+                .collect();
+            assert_eq!(sample_ascii_printable_string(&mut sampler, len), expected);
         }
     }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -153,10 +153,8 @@ where
 
 /// Sample a uniform `u64` in `[0, n)` using rejection sampling.
 ///
-/// Uses `u64` as a pointer-width-independent working domain so the same
-/// draw pattern applies to every finite-domain selection primitive
-/// (`sample_usize_in`, `sample_ratio`, `sample_weighted_index`,
-/// `sample_choice`).
+/// Uses `u64` as a pointer-width-independent working domain, so every
+/// finite-domain selection primitive draws with the same pattern.
 /// Draws are consumed from the RNG only via [`raw_bytes`], so rejected
 /// attempts do not appear in the value trace (rejection span metadata
 /// is still recorded in Recording mode).
@@ -849,6 +847,14 @@ pub fn sample_ascii_char(ctx: &mut TestCaseContext) -> char {
 /// [`sample_choice`] to keep the distribution uniform; for this bound
 /// the per-attempt rejection rate is `< 2⁻⁵⁸`, so a rejected attempt
 /// is effectively never observed.
+///
+/// # Determinism note
+///
+/// Each character consumes an 8-byte bounded draw (a rejected attempt,
+/// which is effectively never observed, consumes another 8 bytes).
+/// This is a deliberate correction over the earlier `% 95` mapping of a
+/// 4-byte draw, which was biased; for the same seed the value stream
+/// therefore differs from earlier releases.
 #[track_caller]
 pub fn sample_ascii_printable_char(ctx: &mut TestCaseContext) -> char {
     let loc = Location::caller();
@@ -1314,10 +1320,14 @@ mod tests {
     fn sample_ascii_printable_char_matches_unbiased_core() {
         // 95 does not divide 2^64, so an unbiased printable draw must
         // come from the shared rejection-sampling core. Two same-seed
-        // contexts advance in lockstep: the direct `sample_below(95)`
-        // stream must equal the char primitive's stream. A `% 95`
-        // mapping is reintroduced this fails, because it consumes a
-        // different number of RNG bytes per char and drifts off-stream.
+        // contexts advance in lockstep — each draws the same PRNG value
+        // per character — so the direct `sample_below(95)` stream must
+        // equal the char primitive's stream. The old `% 95` mapping
+        // reduced only the low 32 bits of the draw, so the same draw
+        // maps to a different character with probability 94/95, failing
+        // this test on the first draw. A biased `% 95` over the full
+        // 64-bit draw would not be detected here; that property rests
+        // on the shared rejection-sampling core.
         let mut core = TestCaseContext::new(0x9E37_79B9_7F4A_7C15);
         let mut sampler = TestCaseContext::new(0x9E37_79B9_7F4A_7C15);
         for _ in 0..1024 {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -847,8 +847,8 @@ pub fn sample_ascii_char(ctx: &mut TestCaseContext) -> char {
 /// so a naive `% 95` would be biased. Uses the same bounded
 /// rejection-sampling core as [`sample_usize_in`] and
 /// [`sample_choice`] to keep the distribution uniform; for this bound
-/// the per-attempt rejection rate is `< 2⁻⁶³`, so a rejection draw is
-/// effectively never taken.
+/// the per-attempt rejection rate is `< 2⁻⁵⁸`, so a rejected attempt
+/// is effectively never observed.
 #[track_caller]
 pub fn sample_ascii_printable_char(ctx: &mut TestCaseContext) -> char {
     let loc = Location::caller();
@@ -950,9 +950,11 @@ pub fn sample_ascii_string(ctx: &mut TestCaseContext, len: usize) -> String {
 /// One trace entry is recorded per call. Each character is drawn via
 /// the same bounded rejection-sampling core as
 /// [`sample_ascii_printable_char`], so a call consumes `len × 8` RNG
-/// bytes plus a rare rejection draw (probability `< 2⁻⁶³` per
-/// character), and opens an attempt span only if a rejection occurs.
-/// Rejected draws do not appear in the value trace.
+/// bytes in the common case (a rejected attempt — probability
+/// `< 2⁻⁵⁸` per character — consumes another 8 bytes) and, in
+/// Recording mode, opens at least `len` attempt spans in the choice
+/// sequence (one per accepted character; each rejected attempt adds
+/// another span). Rejected attempts do not appear in the value trace.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary

`sample_ascii_printable_char` and `sample_ascii_printable_string` mapped a
32-bit draw with `% 95`. Since 2^32 mod 95 = 6, the first six printable
characters were slightly over-represented, contradicting the documented
uniform-distribution contract and noprop's bias-free bounded-sampling policy.

Both paths now draw through the shared rejection-sampling core
(`sample_below` with bound 95; rejection probability 36/2^64 ≈ 2^-58.8),
so every character in `0x20..=0x7E` is equally likely. The string path
routes through the same raw helper, so char and string share one
unbiased sampler. Draws are recorded as `Bounded { bound: 95 }` instead
of `Raw`, which also lets mutation rewrite them in place within the
printable range.

## Notes

- Breaking change for v0.2.0: the value stream for a given seed differs
  from 0.1.x (8 bytes per character instead of 4, and a different
  mapping). Documented in the `sample_ascii_printable_char` determinism
  note; release note recommended for the README.
- The rejection-rate and attempt-span claims in the rustdoc were
  corrected while at it (the recorded `< 2⁻⁶³` bound and the "span only
  on rejection" wording were both wrong).
