### PR TITLE
Add `sample_u64_in` for bounded u64 ranges

### DIFF
--- a/docs/generator-design.md
+++ b/docs/generator-design.md
@@ -33,9 +33,11 @@ A generator's **distribution** is *how* it samples values across the
 support. noprop's primitives are uniform over their support:
 `sample_u32` covers `0..=u32::MAX` uniformly, `sample_usize_in(ctx,
 0..=n)` covers `0..=n` uniformly (through bias-free bounded rejection),
-`sample_u64_in(ctx, 0..=n)` does the same for ranges beyond the
-`usize` width, and `sample_choice(ctx, slice)` picks one slice element
-uniformly. Only `u64` gets an `_in` variant: `usize` already covers
+`sample_u64_in(ctx, 0..=n)` does the same for ranges a `usize` result
+cannot serve (inexpressible on 32-bit targets, a cast on 64-bit), and
+`sample_choice(ctx, slice)` picks one slice element uniformly. Beyond
+the pre-existing `sample_usize_in`, only `u64` gets an integer `_in`
+variant: `usize` already covers
 `u8` / `u16` / `u32` on every 32/64-bit target, `u128` would need
 128-bit rejection sampling without a demonstrated demand, and signed
 ranges are expressible with an offset on top of these primitives.

--- a/docs/generator-design.md
+++ b/docs/generator-design.md
@@ -33,7 +33,12 @@ A generator's **distribution** is *how* it samples values across the
 support. noprop's primitives are uniform over their support:
 `sample_u32` covers `0..=u32::MAX` uniformly, `sample_usize_in(ctx,
 0..=n)` covers `0..=n` uniformly (through bias-free bounded rejection),
-and `sample_choice(ctx, slice)` picks one slice element uniformly.
+`sample_u64_in(ctx, 0..=n)` does the same for ranges beyond the
+`usize` width, and `sample_choice(ctx, slice)` picks one slice element
+uniformly. Only `u64` gets an `_in` variant: `usize` already covers
+`u8` / `u16` / `u32` on every 32/64-bit target, `u128` would need
+128-bit rejection sampling without a demonstrated demand, and signed
+ranges are expressible with an offset on top of these primitives.
 
 Two reasons to move away from uniform:
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -104,8 +104,8 @@ assert!(idx < 10);
 let day = noprop::sample_usize_in(&mut ctx, 1..=31);
 assert!((1..=31).contains(&day));
 
-// u64 range: no cast or bit mask needed, even beyond the usize width
-// (e.g. a 33-bit MPEG-2 timestamp).
+// u64 range: no `as u64` cast or bit mask needed (on 32-bit targets
+// the range does not even fit in usize).
 let ts = noprop::sample_u64_in(&mut ctx, 0..(1u64 << 33));
 assert!(ts < (1u64 << 33));
 
@@ -120,7 +120,8 @@ let _b = noprop::sample_bool(&mut ctx);
 **Notes.** Never write `sample_usize(ctx) % max` for a bounded draw —
 it is biased and overflows at `usize::MAX`. For `u64` ranges use
 [`sample_u64_in`](crate::sample_u64_in) instead of masking with
-`& ((1 << n) - 1)`, which is only uniform for power-of-two widths.
+`& ((1 << n) - 1)`, which can only express zero-offset power-of-two
+ranges and is biased for any other width.
 Length-taking helpers take an *exact* length; combine with
 `sample_usize_in` for a random length (no `(min, max)` overload is
 provided so composition stays the one shape).

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -87,6 +87,7 @@ properties need.
 
 **Uses.** [`sample_u32`](crate::sample_u32) (and the other integer
 `sample_*` primitives), [`sample_usize_in`](crate::sample_usize_in),
+[`sample_u64_in`](crate::sample_u64_in),
 [`sample_string`](crate::sample_string),
 [`sample_ascii_printable_string`](crate::sample_ascii_printable_string),
 [`sample_bool`](crate::sample_bool).
@@ -103,6 +104,11 @@ assert!(idx < 10);
 let day = noprop::sample_usize_in(&mut ctx, 1..=31);
 assert!((1..=31).contains(&day));
 
+// u64 range: no cast or bit mask needed, even beyond the usize width
+// (e.g. a 33-bit MPEG-2 timestamp).
+let ts = noprop::sample_u64_in(&mut ctx, 0..(1u64 << 33));
+assert!(ts < (1u64 << 33));
+
 // Length-taking string primitives: pick the length first, then draw.
 let len = noprop::sample_usize_in(&mut ctx, 0..=32);
 let _s = noprop::sample_string(&mut ctx, len);
@@ -112,12 +118,15 @@ let _b = noprop::sample_bool(&mut ctx);
 ```
 
 **Notes.** Never write `sample_usize(ctx) % max` for a bounded draw —
-it is biased and overflows at `usize::MAX`. Length-taking helpers take
-an *exact* length; combine with `sample_usize_in` for a random length
-(no `(min, max)` overload is provided so composition stays the one
-shape).
+it is biased and overflows at `usize::MAX`. For `u64` ranges use
+[`sample_u64_in`](crate::sample_u64_in) instead of masking with
+`& ((1 << n) - 1)`, which is only uniform for power-of-two widths.
+Length-taking helpers take an *exact* length; combine with
+`sample_usize_in` for a random length (no `(min, max)` overload is
+provided so composition stays the one shape).
 
 **See also.** [`sample_usize_in`](crate::sample_usize_in),
+[`sample_u64_in`](crate::sample_u64_in),
 [`sample_string`](crate::sample_string),
 [`crate::docs::generator_authoring`].
 

--- a/skills/noprop/references/api.md
+++ b/skills/noprop/references/api.md
@@ -53,9 +53,11 @@ implementation details. Inspect the matching source when those values matter.
 | `sample_u8/u16/u32/u64/u128/usize(ctx)` | Uniform unsigned integer of the named type. |
 | `sample_i8/i16/i32/i64/i128/isize(ctx)` | Uniform signed integer of the named type. |
 | `sample_usize_in(ctx, range)` | Uniform `usize` inside any valid `RangeBounds<usize>`. |
+| `sample_u64_in(ctx, range)` | Uniform `u64` inside any valid `RangeBounds<u64>`. |
 
-Use `sample_usize_in(ctx, 0..n)` instead of modulo reduction. Invalid or empty
-ranges panic at the caller.
+Use `sample_usize_in(ctx, 0..n)` / `sample_u64_in(ctx, 0..n)` instead
+of modulo reduction or bit masking. Invalid or empty ranges panic at the
+caller.
 
 ## Bytes, characters, and strings
 

--- a/skills/noprop/references/api.md
+++ b/skills/noprop/references/api.md
@@ -1,9 +1,9 @@
 # noprop API Reference
 
 Read this file when an exact public API, panic condition, or statistic is
-needed. This snapshot targets noprop 0.1.0. Inspect the target project's
-resolved crate version and matching rustdoc before relying on it outside the
-noprop repository.
+needed. This snapshot targets unreleased noprop main (post-0.1.0).
+Inspect the target project's resolved crate version and matching rustdoc
+before relying on it outside the noprop repository.
 
 ## Execution
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -260,6 +260,9 @@ pub fn sample_choice<T: Clone + std::fmt::Debug + 'static>(
 /// `usize::MAX` and biased when the divisor does not evenly divide the
 /// integer domain).
 ///
+/// For `u64` ranges — inexpressible in `usize` on 32-bit targets, and
+/// a cast from `usize` on 64-bit targets — see [`sample_u64_in`].
+///
 /// # Panics
 ///
 /// Panics if `range` is empty (e.g. `5..5`, `5..=4`, `..0`, or an
@@ -319,9 +322,11 @@ pub fn sample_usize_in<R: RangeBounds<usize>>(ctx: &mut TestCaseContext, range: 
 ///
 /// Accepts any `RangeBounds<u64>` — `a..b`, `a..=b`, `..b`, `a..`,
 /// `..`, and so on. The typical use is sampling protocol fields or
-/// timestamps that exceed the `usize` width (e.g. a 33-bit MPEG-2
-/// timestamp) without a cast or bit mask — masking is only uniform for
-/// power-of-two widths.
+/// timestamps that need a `u64` result type (e.g. a 33-bit MPEG-2
+/// timestamp) without a cast or bit mask: a bit mask can only express
+/// zero-offset power-of-two ranges and is biased for any other width,
+/// while `sample_usize_in` returns `usize` — a cast on 64-bit targets,
+/// and a range that does not fit at all on 32-bit targets.
 ///
 /// # Panics
 ///

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -315,6 +315,82 @@ pub fn sample_usize_in<R: RangeBounds<usize>>(ctx: &mut TestCaseContext, range: 
     v
 }
 
+/// Uniformly-distributed `u64` inside `range`.
+///
+/// Accepts any `RangeBounds<u64>` — `a..b`, `a..=b`, `..b`, `a..`,
+/// `..`, and so on. The typical use is sampling protocol fields or
+/// timestamps that exceed the `usize` width (e.g. a 33-bit MPEG-2
+/// timestamp) without a cast or bit mask — masking is only uniform for
+/// power-of-two widths.
+///
+/// # Panics
+///
+/// Panics if `range` is empty (e.g. `5..5`, `5..=4`, `..0`, or an
+/// excluded start of `u64::MAX`).
+///
+/// # Determinism note
+///
+/// Uses rejection sampling internally. Most calls accept the first
+/// draw, but the exact byte count consumed depends on the range width,
+/// so changing the range can shift subsequent RNG output for the same
+/// seed. The full range `..` is a plain integer draw consuming exactly
+/// 8 bytes, so it is byte-equivalent to [`sample_u64`].
+///
+/// # Why no other integer `_in` variants
+///
+/// [`sample_usize_in`] already covers `u8` / `u16` / `u32` on every
+/// 32/64-bit target (`usize` is at least 32 bits there), and `u64` on
+/// 64-bit targets — but its result type is `usize`, so a `u64` field
+/// needs a cast and 32-bit targets cannot express a `u64` range at
+/// all. `sample_u64_in` exists for exactly those cases. A `u128` range
+/// would need 128-bit rejection sampling without a demonstrated
+/// demand, and signed ranges are expressible with an offset on top of
+/// these primitives, so neither is provided.
+///
+/// # Examples
+///
+/// ```
+/// let mut ctx = noprop::TestCaseContext::new(0);
+///
+/// // MPEG-2 33-bit timestamp.
+/// let ts = noprop::sample_u64_in(&mut ctx, 0..(1u64 << 33));
+/// assert!(ts < (1u64 << 33));
+///
+/// // Arbitrary protocol field range.
+/// let field = noprop::sample_u64_in(&mut ctx, 100..=999);
+/// assert!((100..=999).contains(&field));
+/// ```
+#[track_caller]
+pub fn sample_u64_in<R: RangeBounds<u64>>(ctx: &mut TestCaseContext, range: R) -> u64 {
+    let loc = Location::caller();
+    let lo = match range.start_bound() {
+        Bound::Included(&s) => s,
+        Bound::Excluded(&s) => s.checked_add(1).expect("sample_u64_in: empty range"),
+        Bound::Unbounded => 0,
+    };
+    let hi = match range.end_bound() {
+        Bound::Included(&e) => e,
+        Bound::Excluded(&e) => e.checked_sub(1).expect("sample_u64_in: empty range"),
+        Bound::Unbounded => u64::MAX,
+    };
+    assert!(lo <= hi, "sample_u64_in: empty range");
+    let v = if lo == 0 && hi == u64::MAX {
+        // Full-width range: a raw byte draw is already unbiased, and
+        // hi - lo + 1 would wrap. This is a plain integer draw,
+        // byte-equivalent to sample_u64.
+        ctx.set_next_choice_meta(crate::rng::ChoiceMeta::Integer);
+        u64::from_le_bytes(raw_bytes(ctx))
+    } else {
+        // hi - lo cannot overflow because hi >= lo, and (hi - lo) + 1
+        // cannot overflow because we excluded the only case where
+        // hi - lo == u64::MAX.
+        let width = hi - lo + 1;
+        lo + sample_below(ctx, width)
+    };
+    ctx.record_generated(&v, loc);
+    v
+}
+
 /// An exact rational probability `numerator / denominator`.
 ///
 /// The ratio is valid by construction: `denominator` is non-zero and
@@ -1856,6 +1932,126 @@ mod tests {
             (
                 std::ops::Bound::Excluded(usize::MAX),
                 std::ops::Bound::<usize>::Unbounded,
+            ),
+        );
+    }
+
+    // === sample_u64_in ===
+
+    #[test]
+    fn sample_u64_in_exclusive_stays_in_range() {
+        let mut ctx = TestCaseContext::new(1);
+        for _ in 0..1000 {
+            let v = sample_u64_in(&mut ctx, 10..20);
+            assert!((10..20).contains(&v));
+        }
+    }
+
+    #[test]
+    fn sample_u64_in_inclusive_stays_in_range() {
+        let mut ctx = TestCaseContext::new(1);
+        for _ in 0..1000 {
+            let v = sample_u64_in(&mut ctx, 10..=20);
+            assert!((10..=20).contains(&v));
+        }
+    }
+
+    #[test]
+    fn sample_u64_in_single_element_returns_that_element() {
+        let mut ctx = TestCaseContext::new(1);
+        // 5..=5 is one element; the runner should return it without
+        // consuming any RNG.
+        let mut fresh = TestCaseContext::new(1);
+        assert_eq!(sample_u64_in(&mut ctx, 5..=5), 5);
+        assert_state_unadvanced(&mut ctx, &mut fresh);
+    }
+
+    #[test]
+    fn sample_u64_in_hits_both_endpoints() {
+        let mut ctx = TestCaseContext::new(1);
+        let (mut lo, mut hi) = (false, false);
+        for _ in 0..1024 {
+            let v = sample_u64_in(&mut ctx, 0..=3);
+            lo |= v == 0;
+            hi |= v == 3;
+            if lo && hi {
+                return;
+            }
+        }
+        panic!("sample_u64_in did not cover both endpoints");
+    }
+
+    #[test]
+    fn sample_u64_in_full_range_stays_in_range() {
+        let mut ctx = TestCaseContext::new(1);
+        for _ in 0..100 {
+            let _v = sample_u64_in(&mut ctx, ..);
+            // Any u64 is in range; just verify no panic.
+        }
+    }
+
+    #[test]
+    fn sample_u64_in_inclusive_up_to_max_stays_in_range() {
+        // Exercises the max - lo + 1 arithmetic on the widest non-full
+        // range so it must not overflow.
+        let mut ctx = TestCaseContext::new(1);
+        for _ in 0..100 {
+            let v = sample_u64_in(&mut ctx, 1..=u64::MAX);
+            assert!(v >= 1);
+        }
+    }
+
+    #[test]
+    fn sample_u64_in_unbounded_end_stays_in_range() {
+        let mut ctx = TestCaseContext::new(1);
+        for _ in 0..100 {
+            let v = sample_u64_in(&mut ctx, 100..);
+            assert!(v >= 100);
+        }
+    }
+
+    #[test]
+    fn sample_u64_in_is_deterministic() {
+        let mut a = TestCaseContext::new(999);
+        let mut b = TestCaseContext::new(999);
+        for _ in 0..64 {
+            assert_eq!(sample_u64_in(&mut a, 0..137), sample_u64_in(&mut b, 0..137));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "empty range")]
+    fn sample_u64_in_panics_on_empty_exclusive() {
+        let mut ctx = TestCaseContext::new(0);
+        let _ = sample_u64_in(&mut ctx, 5..5);
+    }
+
+    #[test]
+    #[should_panic(expected = "empty range")]
+    fn sample_u64_in_panics_on_reversed_inclusive() {
+        let mut ctx = TestCaseContext::new(0);
+        #[expect(clippy::reversed_empty_ranges)]
+        let _ = sample_u64_in(&mut ctx, 5..=4);
+    }
+
+    #[test]
+    #[should_panic(expected = "empty range")]
+    fn sample_u64_in_panics_on_zero_exclusive_end() {
+        let mut ctx = TestCaseContext::new(0);
+        let _ = sample_u64_in(&mut ctx, ..0);
+    }
+
+    #[test]
+    #[should_panic(expected = "empty range")]
+    fn sample_u64_in_panics_on_excluded_max_start() {
+        let mut ctx = TestCaseContext::new(0);
+        // An excluded start of u64::MAX would need start + 1, which
+        // overflows — semantically the range is empty.
+        let _ = sample_u64_in(
+            &mut ctx,
+            (
+                std::ops::Bound::Excluded(u64::MAX),
+                std::ops::Bound::<u64>::Unbounded,
             ),
         );
     }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -338,8 +338,9 @@ pub fn sample_usize_in<R: RangeBounds<usize>>(ctx: &mut TestCaseContext, range: 
 /// Uses rejection sampling internally. Most calls accept the first
 /// draw, but the exact byte count consumed depends on the range width,
 /// so changing the range can shift subsequent RNG output for the same
-/// seed. The full range `..` is a plain integer draw consuming exactly
-/// 8 bytes, so it is byte-equivalent to [`sample_u64`].
+/// seed. Any full-width range (covering the entire `u64` domain) is a
+/// plain integer draw consuming exactly 8 bytes, so it is
+/// byte-equivalent to [`sample_u64`].
 ///
 /// # Why no other integer `_in` variants
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@ pub use generator::{
     sample_ascii_string, sample_bool, sample_bytes, sample_bytes_vec, sample_char, sample_choice,
     sample_f32, sample_f32_in, sample_f64, sample_f64_in, sample_i8, sample_i16, sample_i32,
     sample_i64, sample_i128, sample_isize, sample_ratio, sample_string, sample_u8, sample_u16,
-    sample_u32, sample_u64, sample_u128, sample_usize, sample_usize_in, sample_weighted_index,
-    sample_with_boundaries, sample_with_rejection,
+    sample_u32, sample_u64, sample_u64_in, sample_u128, sample_usize, sample_usize_in,
+    sample_weighted_index, sample_with_boundaries, sample_with_rejection,
 };
 pub use rng::{GeneratedValue, TestCaseContext};
 pub use runner::{Runner, Stats};

--- a/tests/pbt.rs
+++ b/tests/pbt.rs
@@ -160,6 +160,147 @@ fn sample_usize_in_full_range_matches_sample_usize() -> noprop::TestResult {
     Ok(())
 }
 
+/// Draw a `u64` biased toward the extreme values that a uniform
+/// draw essentially never hits (`0`, `1`, `u64::MAX - 1`,
+/// `u64::MAX`), so range boundaries are actually exercised.
+fn sample_u64_boundary_biased(ctx: &mut noprop::TestCaseContext) -> u64 {
+    noprop::sample_with_boundaries(
+        ctx,
+        &[0, 1, u64::MAX - 1, u64::MAX],
+        noprop::Ratio::one_nth(4),
+        noprop::sample_u64,
+    )
+}
+
+#[test]
+fn sample_u64_in_stays_within_generated_ranges() -> noprop::TestResult {
+    // Verify sample_u64_in respects the inclusion contract for every
+    // non-full range form. The full `..` form is handled separately
+    // (see sample_u64_in_full_range_matches_sample_u64) because "the
+    // returned value is a u64" is vacuous for it.
+    //
+    // Boundaries (`0`, `1`, `u64::MAX - 1`, `u64::MAX`) are mixed
+    // in via sample_u64_boundary_biased so extreme-endpoint cases
+    // (empty-exclusive shift, `..0` shift, high-u64 ranges) are
+    // actually reached; coverage counters below fail the test if any
+    // form or any endpoint class is missed.
+    const FORMS: usize = 5; // lo..hi / lo..=hi / lo.. / ..hi / ..=hi
+    const BOUNDARIES: usize = 4; // 0 / 1 / MAX-1 / MAX
+
+    let form_seen: Cell<[bool; FORMS]> = Cell::new([false; FORMS]);
+    let boundary_seen: Cell<[bool; BOUNDARIES]> = Cell::new([false; BOUNDARIES]);
+
+    noprop::Runner::new(ROOT_SEED).run(1024, |ctx| {
+        let form = noprop::sample_usize_in(ctx, 0..FORMS);
+        let a = sample_u64_boundary_biased(ctx);
+        let b = sample_u64_boundary_biased(ctx);
+        let (lo_raw, hi_raw) = if a <= b { (a, b) } else { (b, a) };
+
+        let mut forms = form_seen.get();
+        forms[form] = true;
+        form_seen.set(forms);
+
+        let mut bounds = boundary_seen.get();
+        for &v in &[a, b] {
+            if v == 0 {
+                bounds[0] = true;
+            }
+            if v == 1 {
+                bounds[1] = true;
+            }
+            if v == u64::MAX - 1 {
+                bounds[2] = true;
+            }
+            if v == u64::MAX {
+                bounds[3] = true;
+            }
+        }
+        boundary_seen.set(bounds);
+
+        match form {
+            0 => {
+                // lo..hi (exclusive): require lo < hi. If a == b, shift
+                // one endpoint by 1 (u64::MAX case: shift lo down
+                // instead of hi up, to stay in-domain).
+                let (lo, hi) = if lo_raw < hi_raw {
+                    (lo_raw, hi_raw)
+                } else if lo_raw == u64::MAX {
+                    (lo_raw - 1, hi_raw)
+                } else {
+                    (lo_raw, hi_raw + 1)
+                };
+                let v = noprop::sample_u64_in(ctx, lo..hi);
+                assert!(lo <= v && v < hi, "lo..hi: v={v} not in [{lo}, {hi})");
+            }
+            1 => {
+                // lo..=hi (inclusive): a == b is a legal singleton
+                // range.
+                let (lo, hi) = (lo_raw, hi_raw);
+                let v = noprop::sample_u64_in(ctx, lo..=hi);
+                assert!(lo <= v && v <= hi, "lo..=hi: v={v} not in [{lo}, {hi}]");
+            }
+            2 => {
+                // lo..
+                let lo = lo_raw;
+                let v = noprop::sample_u64_in(ctx, lo..);
+                assert!(v >= lo, "lo..: v={v} < {lo}");
+            }
+            3 => {
+                // ..hi (exclusive): hi > 0 required, so shift `..0` to
+                // `..1` (a legal one-element range).
+                let hi = if hi_raw == 0 { 1 } else { hi_raw };
+                let v = noprop::sample_u64_in(ctx, ..hi);
+                assert!(v < hi, "..hi: v={v} >= {hi}");
+            }
+            _ => {
+                // ..=hi (inclusive): any hi is legal, including 0 and
+                // u64::MAX.
+                let hi = hi_raw;
+                let v = noprop::sample_u64_in(ctx, ..=hi);
+                assert!(v <= hi, "..=hi: v={v} > {hi}");
+            }
+        }
+        Ok(())
+    })?;
+
+    for (i, hit) in form_seen.get().iter().enumerate() {
+        assert!(*hit, "range form index {i} was not exercised");
+    }
+    for (i, hit) in boundary_seen.get().iter().enumerate() {
+        let label = ["0", "1", "u64::MAX - 1", "u64::MAX"][i];
+        assert!(*hit, "boundary class {label} was not exercised");
+    }
+    Ok(())
+}
+
+#[test]
+fn sample_u64_in_full_range_matches_sample_u64() -> noprop::TestResult {
+    // The full range `..` has no non-vacuous inclusion assertion, so
+    // cover it with a differential oracle against sample_u64 on
+    // identical seeds. The follow-up sample_u64 comparison catches
+    // regressions that return the same first value but consume a
+    // different number of bytes.
+    noprop::Runner::new(ROOT_SEED.wrapping_add(2)).run(256, |ctx| {
+        let seed = noprop::sample_u64(ctx);
+        let mut actual_ctx = noprop::TestCaseContext::new(seed);
+        let mut expected_ctx = noprop::TestCaseContext::new(seed);
+
+        let actual = noprop::sample_u64_in(&mut actual_ctx, ..);
+        let expected = noprop::sample_u64(&mut expected_ctx);
+        assert_eq!(
+            actual, expected,
+            "seed={seed:#x}: full-range sample_u64_in must match sample_u64"
+        );
+        assert_eq!(
+            noprop::sample_u64(&mut actual_ctx),
+            noprop::sample_u64(&mut expected_ctx),
+            "seed={seed:#x}: follow-up bytes diverged"
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
+
 #[test]
 fn sample_ratio_matches_explicit_recipe() -> noprop::TestResult {
     // sample_ratio(Ratio::new(n, d)) must equal:

--- a/tests/pbt.rs
+++ b/tests/pbt.rs
@@ -39,10 +39,11 @@ fn sample_usize_in_stays_within_generated_ranges() -> noprop::TestResult {
     // "the returned value is a usize" is vacuous for it.
     //
     // Boundaries (`0`, `1`, `usize::MAX - 1`, `usize::MAX`) are mixed
-    // in via sample_usize_boundary_biased so extreme-endpoint cases
-    // (empty-exclusive shift, `..0` shift, high-usize ranges) are
-    // actually reached; coverage counters below fail the test if any
-    // form or any endpoint class is missed.
+    // in via sample_usize_boundary_biased, and the coverage counters
+    // below fail the test if any range form or any boundary class is
+    // never drawn. They do not guarantee every form x boundary-position
+    // combination is exercised — some joints (e.g. `..=0`) may not
+    // occur for this seed.
     const FORMS: usize = 5; // lo..hi / lo..=hi / lo.. / ..hi / ..=hi
     const BOUNDARIES: usize = 4; // 0 / 1 / MAX-1 / MAX
 
@@ -262,10 +263,11 @@ fn sample_u64_in_stays_within_generated_ranges() -> noprop::TestResult {
     // returned value is a u64" is vacuous for it.
     //
     // Boundaries (`0`, `1`, `u64::MAX - 1`, `u64::MAX`) are mixed
-    // in via sample_u64_boundary_biased so extreme-endpoint cases
-    // (empty-exclusive shift, `..0` shift, high-u64 ranges) are
-    // actually reached; coverage counters below fail the test if any
-    // form or any endpoint class is missed.
+    // in via sample_u64_boundary_biased, and the coverage counters
+    // below fail the test if any range form or any boundary class is
+    // never drawn. They do not guarantee every form x boundary-position
+    // combination is exercised — some joints (e.g. `..=0`) may not
+    // occur for this seed.
     const FORMS: usize = 5; // lo..hi / lo..=hi / lo.. / ..hi / ..=hi
     const BOUNDARIES: usize = 4; // 0 / 1 / MAX-1 / MAX
 
@@ -362,7 +364,7 @@ fn sample_u64_in_full_range_matches_sample_u64() -> noprop::TestResult {
     // identical seeds. The follow-up sample_u64 comparison catches
     // regressions that return the same first value but consume a
     // different number of bytes.
-    noprop::Runner::new(ROOT_SEED.wrapping_add(2)).run(256, |ctx| {
+    noprop::Runner::new(ROOT_SEED.wrapping_add(12)).run(256, |ctx| {
         let seed = noprop::sample_u64(ctx);
         let mut actual_ctx = noprop::TestCaseContext::new(seed);
         let mut expected_ctx = noprop::TestCaseContext::new(seed);

--- a/tests/pbt.rs
+++ b/tests/pbt.rs
@@ -160,6 +160,88 @@ fn sample_usize_in_full_range_matches_sample_usize() -> noprop::TestResult {
     Ok(())
 }
 
+#[test]
+fn sample_usize_in_excluded_start_matches_inclusive_recipe() -> noprop::TestResult {
+    // Differential oracle for the excluded start-bound success path
+    // (the `checked_add(1)` in sample_usize_in): every excluded-start
+    // form must equal its inclusive/half-open equivalent on identical
+    // seeds, in value and in follow-up bytes. A regression that shifts
+    // the excluded-start offset (e.g. checked_add(1) -> checked_add(2))
+    // changes the sampled width and is caught deterministically.
+    //
+    // `s` is boundary-biased so the extreme arithmetic is exercised
+    // (s == 0 -> lo == 1; s == usize::MAX - 1 -> lo == usize::MAX); the
+    // s == usize::MAX empty-range panic is covered by the unit test
+    // sample_usize_in_panics_on_excluded_max_start. Coverage counters
+    // fail the test if any end-bound form is missed.
+    const FORMS: usize = 3; // (Excluded(s), Included(e)) / (Excluded(s), Excluded(e)) / (Excluded(s), Unbounded)
+    let form_seen: Cell<[bool; FORMS]> = Cell::new([false; FORMS]);
+
+    noprop::Runner::new(ROOT_SEED.wrapping_add(11)).run(1024, |ctx| {
+        let form = noprop::sample_usize_in(ctx, 0..FORMS);
+        let a = sample_usize_boundary_biased(ctx);
+        let b = sample_usize_boundary_biased(ctx);
+        let (s, e) = if a <= b { (a, b) } else { (b, a) };
+
+        // Non-empty conditions (lo = s + 1, hi as per end bound):
+        //   Included(e): s + 1 <= e        (s < e)
+        //   Excluded(e): s + 1 <= e - 1    (s + 2 <= e)
+        //   Unbounded:   s + 1 <= usize::MAX (s < usize::MAX)
+        let valid = match form {
+            0 => s < e,
+            1 => s.checked_add(2).is_some_and(|lo| lo <= e),
+            _ => s < usize::MAX,
+        };
+        if !valid {
+            return Ok(());
+        }
+
+        let mut forms = form_seen.get();
+        forms[form] = true;
+        form_seen.set(forms);
+
+        let seed = noprop::sample_u64(ctx);
+        let mut actual_ctx = noprop::TestCaseContext::new(seed);
+        let mut expected_ctx = noprop::TestCaseContext::new(seed);
+
+        let actual = match form {
+            0 => noprop::sample_usize_in(
+                &mut actual_ctx,
+                (std::ops::Bound::Excluded(s), std::ops::Bound::Included(e)),
+            ),
+            1 => noprop::sample_usize_in(
+                &mut actual_ctx,
+                (std::ops::Bound::Excluded(s), std::ops::Bound::Excluded(e)),
+            ),
+            _ => noprop::sample_usize_in(
+                &mut actual_ctx,
+                (
+                    std::ops::Bound::Excluded(s),
+                    std::ops::Bound::<usize>::Unbounded,
+                ),
+            ),
+        };
+        let expected = match form {
+            0 => noprop::sample_usize_in(&mut expected_ctx, s + 1..=e),
+            1 => noprop::sample_usize_in(&mut expected_ctx, s + 1..e),
+            _ => noprop::sample_usize_in(&mut expected_ctx, s + 1..),
+        };
+
+        assert_eq!(actual, expected, "seed={seed:#x} s={s} e={e} form={form}");
+        assert_eq!(
+            noprop::sample_u64(&mut actual_ctx),
+            noprop::sample_u64(&mut expected_ctx),
+            "seed={seed:#x} s={s} e={e} form={form}: follow-up bytes diverged"
+        );
+        Ok(())
+    })?;
+
+    for (i, hit) in form_seen.get().iter().enumerate() {
+        assert!(*hit, "excluded-start form index {i} was not exercised");
+    }
+    Ok(())
+}
+
 /// Draw a `u64` biased toward the extreme values that a uniform
 /// draw essentially never hits (`0`, `1`, `u64::MAX - 1`,
 /// `u64::MAX`), so range boundaries are actually exercised.
@@ -298,6 +380,88 @@ fn sample_u64_in_full_range_matches_sample_u64() -> noprop::TestResult {
         );
         Ok(())
     })?;
+    Ok(())
+}
+
+#[test]
+fn sample_u64_in_excluded_start_matches_inclusive_recipe() -> noprop::TestResult {
+    // Differential oracle for the excluded start-bound success path
+    // (the `checked_add(1)` in sample_u64_in): every excluded-start
+    // form must equal its inclusive/half-open equivalent on identical
+    // seeds, in value and in follow-up bytes. A regression that shifts
+    // the excluded-start offset (e.g. checked_add(1) -> checked_add(2))
+    // changes the sampled width and is caught deterministically.
+    //
+    // `s` is boundary-biased so the extreme arithmetic is exercised
+    // (s == 0 -> lo == 1; s == u64::MAX - 1 -> lo == u64::MAX); the
+    // s == u64::MAX empty-range panic is covered by the unit test
+    // sample_u64_in_panics_on_excluded_max_start. Coverage counters
+    // fail the test if any end-bound form is missed.
+    const FORMS: usize = 3; // (Excluded(s), Included(e)) / (Excluded(s), Excluded(e)) / (Excluded(s), Unbounded)
+    let form_seen: Cell<[bool; FORMS]> = Cell::new([false; FORMS]);
+
+    noprop::Runner::new(ROOT_SEED.wrapping_add(10)).run(1024, |ctx| {
+        let form = noprop::sample_usize_in(ctx, 0..FORMS);
+        let a = sample_u64_boundary_biased(ctx);
+        let b = sample_u64_boundary_biased(ctx);
+        let (s, e) = if a <= b { (a, b) } else { (b, a) };
+
+        // Non-empty conditions (lo = s + 1, hi as per end bound):
+        //   Included(e): s + 1 <= e        (s < e)
+        //   Excluded(e): s + 1 <= e - 1    (s + 2 <= e)
+        //   Unbounded:   s + 1 <= u64::MAX (s < u64::MAX)
+        let valid = match form {
+            0 => s < e,
+            1 => s.checked_add(2).is_some_and(|lo| lo <= e),
+            _ => s < u64::MAX,
+        };
+        if !valid {
+            return Ok(());
+        }
+
+        let mut forms = form_seen.get();
+        forms[form] = true;
+        form_seen.set(forms);
+
+        let seed = noprop::sample_u64(ctx);
+        let mut actual_ctx = noprop::TestCaseContext::new(seed);
+        let mut expected_ctx = noprop::TestCaseContext::new(seed);
+
+        let actual = match form {
+            0 => noprop::sample_u64_in(
+                &mut actual_ctx,
+                (std::ops::Bound::Excluded(s), std::ops::Bound::Included(e)),
+            ),
+            1 => noprop::sample_u64_in(
+                &mut actual_ctx,
+                (std::ops::Bound::Excluded(s), std::ops::Bound::Excluded(e)),
+            ),
+            _ => noprop::sample_u64_in(
+                &mut actual_ctx,
+                (
+                    std::ops::Bound::Excluded(s),
+                    std::ops::Bound::<u64>::Unbounded,
+                ),
+            ),
+        };
+        let expected = match form {
+            0 => noprop::sample_u64_in(&mut expected_ctx, s + 1..=e),
+            1 => noprop::sample_u64_in(&mut expected_ctx, s + 1..e),
+            _ => noprop::sample_u64_in(&mut expected_ctx, s + 1..),
+        };
+
+        assert_eq!(actual, expected, "seed={seed:#x} s={s} e={e} form={form}");
+        assert_eq!(
+            noprop::sample_u64(&mut actual_ctx),
+            noprop::sample_u64(&mut expected_ctx),
+            "seed={seed:#x} s={s} e={e} form={form}: follow-up bytes diverged"
+        );
+        Ok(())
+    })?;
+
+    for (i, hit) in form_seen.get().iter().enumerate() {
+        assert!(*hit, "excluded-start form index {i} was not exercised");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Adds `sample_u64_in(ctx, range)` for uniform, bias-free `u64` draws over
any `RangeBounds<u64>` — `a..b`, `a..=b`, `..b`, `a..`, `..`. This
completes the bounded-range family: `sample_usize_in` cannot express
`u64` ranges on 32-bit targets and returns `usize`, forcing a cast for
`u64` fields on 64-bit targets.

Implementation reuses the shared rejection-sampling core:
- full-width ranges (`..`, `0..`, `..=u64::MAX`, `0..=u64::MAX`) are a
  plain 8-byte integer draw, byte-equivalent to `sample_u64`
- other ranges draw through `sample_below` with `Bounded` metadata, so
  feedback-guided mutation stays constraint-aware
- empty ranges panic at the caller with `#[track_caller]` location

Only `u64` gets an integer `_in` variant — `usize` already covers
`u8`/`u16`/`u32` on every 32/64-bit target, and `u128`/signed have no
demonstrated demand. This rationale is documented in the rustdoc and
the generator-design doc.
